### PR TITLE
Fix missing dist output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "next build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
Add `vercel.json` to configure Vercel's build command and output directory for a Next.js project.

This resolves the "No Output Directory named dist" error by explicitly setting the `outputDirectory` to `.next`, which is the default output for Next.js builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ec587ba-d700-4c34-af27-3c6159a51de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ec587ba-d700-4c34-af27-3c6159a51de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

